### PR TITLE
Users can now opt-out of public assessment

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -51,7 +51,7 @@ def signup():
         password1 = request.form.get('password1')
         password2 = request.form.get('password2')
         pronouns = request.form.get('pronouns')
-
+        opt_out = 'optOut' in request.form
 
         email_exist = User.query.filter_by(email=email).first()
         username_exist = User.query.filter_by(username=username).first()
@@ -80,6 +80,11 @@ def signup():
             db.session.add(new_user)
             #persist changes to db
             db.session.commit()
+
+            if opt_out:
+                with open('no_match_users.txt', 'a') as file:
+                    file.write(username + '\n')
+
             login_user(new_user, remember=True)
             flash('Account created!', category='success')
 

--- a/website/static/main.css
+++ b/website/static/main.css
@@ -10,7 +10,7 @@ body {
 
   .navbar-nav .nav-item.nav-link {
     font-family: Arial, sans-serif;
-    color: #fff;
+    color: #EDB6C0;
     font-size: 17px;
     font-weight: 550;
     margin-right: 10px;
@@ -18,7 +18,7 @@ body {
 }
 
   .navbar-nav .nav-item.nav-link:hover {
-    color: #EDB6C0;
+    color: #fff;
   }
 
   .center-container {

--- a/website/templates/signup.html
+++ b/website/templates/signup.html
@@ -50,6 +50,13 @@
                 <div class="invalid-feedback">Please confirm password</div>
                 {% endif %}
             </div>
+            <div>
+                <p>This application allows for you and other users to assess your compatibility with one another. Would you like to opt out of other users being able to assess their compatibility with you?</p>
+            </div>
+            <div class="form-group">
+                <label for="optOut">Opt out of public compatibility assessment:</label>
+                <input type="checkbox" id="optOut" name="optOut" />
+            </div>
             <br />
             <button type="submit">Submit</button>
         </form>

--- a/website/views.py
+++ b/website/views.py
@@ -70,6 +70,10 @@ def scoring():
         selected_username = request.form.get('selected_username')
         current_username = get_current_username()
 
+        if not_match(selected_username):
+            flash('The selected user cannot be compared with.', category='error')
+            return redirect(url_for('views.match'))
+
         score = isolate_responses(current_username, selected_username)
         #display using flash for now
         #will improve later 
@@ -79,3 +83,9 @@ def scoring():
             flash('An error has occured. Make sure that you have first taken the survey before this step or make sure that the username you entered is valid.', category='error')
 
     return redirect(url_for('views.match'))
+
+#check if user's username is in file
+def not_match(username):
+    with open('no_match_users.txt', 'r') as file:
+        is_in_file = [line.strip() for line in file]
+    return username in is_in_file


### PR DESCRIPTION
I have now implemented a suggestion that was made at my first FYP demo which was to allow the users to opt-out of having their quiz responses used during compatibility assessment in the case of another user possibly guessing their username. This allows for heightened privacy for users if they wish. The code works by adding the usernames of users why opt-out to a text file and then reading from that same file to check if that username exists in the file after a username is entered on the match.html page.